### PR TITLE
Allowance of WS-connections from all origins added

### DIFF
--- a/cmd/eventrecorder/cmd/replay.go
+++ b/cmd/eventrecorder/cmd/replay.go
@@ -30,7 +30,10 @@ var replayCmd = &cobra.Command{
 	},
 }
 
-var upgrader = websocket.Upgrader{}
+// for frontend dev purposes connections from a different source must be (temporarily) allowed
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
 
 func handle(w http.ResponseWriter, r *http.Request) {
 	logger := logger.With(zap.String("remote_address", r.RemoteAddr))


### PR DESCRIPTION
This changes allow you to develop from your browsers console and / or a seperate locally hosted frontend. Quite necessary for developing frontend sites using data sent by Vantage Events.